### PR TITLE
Set-access-range-restrictions#3

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :authenticate_user!
+  before_action :move_to_index, except: [:show]
   
   def show
     @user = User.find(params[:id])


### PR DESCRIPTION
# What
Expanding the scope of disclosure.

# Why
To let unregistered users know the contents of the application.